### PR TITLE
Add regex escaping for PHP 7.3 support

### DIFF
--- a/src/lib/simple_html_dom.php
+++ b/src/lib/simple_html_dom.php
@@ -686,7 +686,7 @@ class simple_html_dom_node
 // This implies that an html attribute specifier may start with an @ sign that is NOT captured by the expression.
 // farther study is required to determine of this should be documented or removed.
 //		$pattern = "/([\w-:\*]*)(?:\#([\w-]+)|\.([\w-]+))?(?:\[@?(!?[\w-]+)(?:([!*^$]?=)[\"']?(.*?)[\"']?)?\])?([\/, ]+)/is";
-		$pattern = "/([\w-:\*]*)(?:\#([\w-]+)|\.([\w-]+))?(?:\[@?(!?[\w-:]+)(?:([!*^$]?=)[\"']?(.*?)[\"']?)?\])?([\/, ]+)/is";
+		$pattern = "/([\w\-:\*]*)(?:\#([\w\-]+)|\.([\w\-]+))?(?:\[@?(!?[\w\-:]+)(?:([!*^$]?=)[\"']?(.*?)[\"']?)?\])?([\/, ]+)/is";
 		preg_match_all($pattern, trim($selector_string).' ', $matches, PREG_SET_ORDER);
 		if (is_object($debug_object)) {$debug_object->debug_log(2, "Matches Array: ", $matches);}
 
@@ -1382,7 +1382,7 @@ class simple_html_dom
 			return true;
 		}
 
-		if (!preg_match("/^[\w-:]+$/", $tag)) {
+		if (!preg_match("/^[\w\-:]+$/", $tag)) {
 			$node->_[HDOM_INFO_TEXT] = '<' . $tag . $this->copy_until('<>');
 			if ($this->char==='<') {
 				$this->link_nodes($node, false);

--- a/src/twig/TwigExtensions.php
+++ b/src/twig/TwigExtensions.php
@@ -226,7 +226,7 @@ class TwigExtensions extends \Twig_Extension
      *
      * @return string|null
      */
-    private function readImageSize(string $url): ?array
+    private function readImageSize(string $url)
     {
         $client = new FasterImage();
 


### PR DESCRIPTION
After testing going from 7.2 to 7.3, amp pages have come back with the following error:

yii\base\ErrorException
preg_match(): Compilation failed: invalid range in character class at offset 4

[Comparison between 7.3 and 7.2](https://3v4l.org/tWdRDe)

It looks like escaping the `-` fixes the issue: [same code with escaped - character](https://3v4l.org/BrbHQ)

Also occurs on line 690: https://3v4l.org/s1iBf vs fixed: https://3v4l.org/JngrX

[This](https://github.com/thujohn/twitter/issues/250) looks to be the same issue, and was fixed the same way: [Escape - character so regex works on PHP 7.3](https://github.com/ejunker/twitter/commit/51295e6af1d28f1f414081fbdc5b471e115b1a5e)

modified the regex to escape the `-` character

Full stack trace: (line 1385)

`yii\base\ErrorException: preg_match(): Compilation failed: invalid range in character class at offset 4
#35 /code/vendor/balazscsaba2006/amplify/src/lib/simple_html_dom.php(1385): handleError
#34 /code/vendor/craftcms/cms/src/web/ErrorHandler.php(81): handleError
#33 /code/vendor/craftcms/cms/src/web/ErrorHandler.php(0): preg_match
#32 /code/vendor/balazscsaba2006/amplify/src/lib/simple_html_dom.php(1385): read_tag
#31 /code/vendor/balazscsaba2006/amplify/src/lib/simple_html_dom.php(1189): parse
#30 /code/vendor/balazscsaba2006/amplify/src/lib/simple_html_dom.php(1083): load
#29 /code/vendor/balazscsaba2006/amplify/src/lib/simple_html_dom.php(97): str_get_html
#28 /code/vendor/balazscsaba2006/amplify/src/twig/TwigExtensions.php(116): amplifyImages
#27 /code/vendor/balazscsaba2006/amplify/src/twig/TwigExtensions.php(49): amplifyFilter
#26 /code/storage/runtime/compiled_templates/d5/d5517916784eba6cb58541b834b8be3826867112c7eef1bcdf77599be2e46753.php(51): doDisplay
#25 /code/vendor/twig/twig/src/Template.php(379): displayWithErrorHandling
#24 /code/vendor/craftcms/cms/src/web/twig/Template.php(52): displayWithErrorHandling
#23 /code/vendor/twig/twig/src/Template.php(356): display
#22 /code/vendor/craftcms/cms/src/web/twig/Template.php(34): display
#21 /code/storage/runtime/compiled_templates/b7/b70040e57c2de9211df8fba8b38591f7dedb8b1402d229235e2b2f8bfa518d9f.php(2744): doDisplay
#20 /code/vendor/twig/twig/src/Template.php(379): displayWithErrorHandling
#19 /code/vendor/craftcms/cms/src/web/twig/Template.php(52): displayWithErrorHandling
#18 /code/vendor/twig/twig/src/Template.php(356): display
#17 /code/vendor/craftcms/cms/src/web/twig/Template.php(34): display
#16 /code/vendor/twig/twig/src/Template.php(364): render
#15 /code/vendor/twig/twig/src/TemplateWrapper.php(45): render
#14 /code/vendor/twig/twig/src/Environment.php(319): render
#13 /code/vendor/craftcms/cms/src/web/View.php(343): renderTemplate
#12 /code/vendor/craftcms/cms/src/web/View.php(393): renderPageTemplate
#11 /code/vendor/craftcms/cms/src/web/Controller.php(161): renderTemplate
#10 /code/vendor/craftcms/cms/src/controllers/TemplatesController.php(78): actionRender
#9 /code/vendor/craftcms/cms/src/controllers/TemplatesController.php(0): call_user_func_array
#8 /code/vendor/yiisoft/yii2/base/InlineAction.php(57): runWithParams
#7 /code/vendor/yiisoft/yii2/base/Controller.php(157): runAction
#6 /code/vendor/craftcms/cms/src/web/Controller.php(109): runAction
#5 /code/vendor/yiisoft/yii2/base/Module.php(528): runAction
#4 /code/vendor/craftcms/cms/src/web/Application.php(297): runAction
#3 /code/vendor/yiisoft/yii2/web/Application.php(103): handleRequest
#2 /code/vendor/craftcms/cms/src/web/Application.php(286): handleRequest
#1 /code/vendor/yiisoft/yii2/base/Application.php(386): run
#0 index.php(21): null`