### PR TITLE
Refactor destructured variables and return type to be more backwards compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,6 @@
 - Ensure version number matches Git tags
 - Refactored Twig extension logic to work on older versions of PHP 7
 
-## 1.0.5 - 2019-04-18
+## 1.0.6 - 2019-04-18
 ### Fixed
 - Remove return type on Twig Extension because it caused issues in some PHP environments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@
 ## 1.0.3 - 2018-07-06
 ### Fixed
 - Downgraded to PHP 7.0
+
+## 1.0.4 - 2019-03-26
+### Fixed
+- Refactored Twig extension logic to work on older versions of PHP 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 - Downgraded to PHP 7.0
 
-## 1.0.4 - 2019-03-26
+## 1.0.5 - 2019-03-26
 ### Fixed
+- Ensure version number matches Git tags
 - Refactored Twig extension logic to work on older versions of PHP 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,7 @@
 ### Fixed
 - Ensure version number matches Git tags
 - Refactored Twig extension logic to work on older versions of PHP 7
+
+## 1.0.5 - 2019-04-18
+### Fixed
+- Remove return type on Twig Extension because it caused issues in some PHP environments

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "balazscsaba2006/amplify",
+  "name": "trendyminds/amplify",
   "description": "Twig filter for the Craft CMS 3 to optimize rich text content for Google AMP.",
   "type": "craft-plugin",
   "keywords": [

--- a/src/twig/TwigExtensions.php
+++ b/src/twig/TwigExtensions.php
@@ -128,7 +128,8 @@ class TwigExtensions extends \Twig_Extension
                         continue;
                     }
 
-                    [$width, $height] = $size;
+                    $width = $size[0];
+                    $height = $size[1];
 
                     // no dimensions should remove this image from DOM permanently
                     if (!$width || !$height) {
@@ -154,7 +155,8 @@ class TwigExtensions extends \Twig_Extension
 
                 // read dimensions from image resource
                 if ($size = $this->readImageSize($src)) {
-                    [$width, $height] = $size;
+                    $width = $size[0];
+                    $height = $size[1];
 
                     $this->setImageSize($img, $width, $height);
                     continue;
@@ -226,7 +228,7 @@ class TwigExtensions extends \Twig_Extension
      *
      * @return string|null
      */
-    private function readImageSize(string $url): ?array
+    private function readImageSize(string $url)
     {
         $client = new FasterImage();
 

--- a/src/twig/TwigExtensions.php
+++ b/src/twig/TwigExtensions.php
@@ -218,7 +218,7 @@ class TwigExtensions extends \Twig_Extension
      * @param int    $height
      * @param int    $expire | Defaults to 604800 (1 week)
      */
-    private function cacheImageSize($key, $width, $height, $expire = 604800): void
+    private function cacheImageSize($key, $width, $height, $expire = 604800)
     {
         \Craft::$app->cache->set(hash('crc32', $key), [$width, $height], $expire);
     }


### PR DESCRIPTION
This fixes #3 

I'm not _entirely_ sure why, but the destructured variables and return type were both throwing errors in the PHP environment I was using. This includes some minor adjustments to make the plugin a bit more backwards compatible.